### PR TITLE
Fix unique IDs issue with the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
       label: Steps to reproduce
       description: Provide the steps to reproduce the issue in as much detail as possible.
       placeholder: |
-        Steps to reproduc:
+        Steps to reproduce:
         1. Do thing
         2. Observe behavior
         3. See error logs below


### PR DESCRIPTION
There is currently an issue with the bug report template not having unique IDs, and therefore not being a valid issue template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bug report template with clearer, semantic field labels (Observed, Expected, Steps to reproduce, Additional).
  * Improved placeholder and description text for the reproduction steps and additional information fields.
  * Left the initial description block unchanged and made no changes to validations or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->