### PR TITLE
Fix package-manager-strict line in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 engine-strict=true
-package-manager-strict=truec
+package-manager-strict=true


### PR DESCRIPTION
Currently set to `truec` when it should be `true`, therefore not making it a valid file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a configuration syntax error to ensure proper validation of package manager settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->